### PR TITLE
chore(next-config): Remove experimental `typedRoutes` config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,9 +4,7 @@ import withBundleAnalyzer from '@next/bundle-analyzer'
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    typedRoutes: true,
-  },
+  /* config options here */
 }
 
 const bundleAnalyzerConfig = withBundleAnalyzer({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ♥️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/vicasas/next.js-boilerplate/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

<!-- Please include a summary of the changes and the purpose of them -->

We will no longer enable experimental features by default. This also paves the way for a smoother migration to Next.js 15.