### PR TITLE
chore(types): Add `__VERSION__` property to `Window` interface for app versioning

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,3 +1,8 @@
 declare global {
-  interface Window {}
+  interface Window {
+    /**
+     * The version of the application.
+     */
+    __VERSION__: string
+  }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ♥️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/vicasas/next.js-boilerplate/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

<!-- Please include a summary of the changes and the purpose of them -->

Placeholder, similar to `env.d.ts`. This also facilitates a smoother migration to Next.js 15. In Next.js 15, the default ESLint rules for TypeScript disallow empty types.