### PR TITLE
chore(lint-staged): Add JSDoc type definition

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -10,6 +10,9 @@ const buildPrettierCommand = (filenames) =>
     .map((f) => path.relative(process.cwd(), f))
     .join(' ')}`
 
+/**
+ * @type {import('lint-staged').Configuration}
+ */
 const lintStagedConfig = {
   '**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}': [
     buildEslintCommand,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ♥️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/vicasas/next.js-boilerplate/blob/HEAD/CONTRIBUTING.md#sending-a-pull-request).

<!-- Please include a summary of the changes and the purpose of them -->

Since version 15.4.0, JSDoc type definition is supported. Learn more: https://github.com/lint-staged/lint-staged/blob/HEAD/CHANGELOG.md#1540